### PR TITLE
feat: 사용자별 권한 설정

### DIFF
--- a/techeerzip/src/main/java/backend/techeerzip/TecheerzipApplication.java
+++ b/techeerzip/src/main/java/backend/techeerzip/TecheerzipApplication.java
@@ -6,7 +6,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-//@PropertySource("classpath:env.properties")
+// @PropertySource("classpath:env.properties")
 public class TecheerzipApplication {
 
     public static void main(String[] args) {

--- a/techeerzip/src/main/java/backend/techeerzip/domain/auth/jwt/CustomUserPrincipal.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/auth/jwt/CustomUserPrincipal.java
@@ -1,10 +1,13 @@
 package backend.techeerzip.domain.auth.jwt;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import backend.techeerzip.domain.role.entity.RoleType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -15,7 +18,21 @@ public class CustomUserPrincipal implements UserDetails {
     private final Long userId;
     private final String email;
     private final String password;
+    private final RoleType role;
     private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserPrincipal(Long userId, String email, String password, RoleType role) {
+        this.userId = userId;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.authorities = List.of(new SimpleGrantedAuthority(role.getRoleName().toUpperCase()));
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
 
     @Override
     public String getUsername() {

--- a/techeerzip/src/main/java/backend/techeerzip/domain/auth/service/CustomUserDetailsService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/auth/service/CustomUserDetailsService.java
@@ -1,6 +1,6 @@
 package backend.techeerzip.domain.auth.service;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import backend.techeerzip.domain.auth.jwt.CustomUserPrincipal;
+import backend.techeerzip.domain.role.entity.RoleType;
 import backend.techeerzip.domain.user.entity.User;
 import backend.techeerzip.domain.user.exception.UserNotFoundException;
 import backend.techeerzip.domain.user.repository.UserRepository;
@@ -44,7 +45,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         if (email.equals(swaggerUsername)) {
             return org.springframework.security.core.userdetails.User.withUsername(swaggerUsername)
                     .password(passwordEncoder.encode(swaggerPassword))
-                    .roles("USER")
+                    .roles("BOOTCAMP")
                     .build();
         }
 
@@ -58,14 +59,21 @@ public class CustomUserDetailsService implements UserDetailsService {
                                     return new UserNotFoundException();
                                 });
 
-        logger.info("사용자 조회 성공 - userId: {}, email: {}", user.getId(), user.getEmail(), CONTEXT);
-
-        GrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + user.getRole().getName());
-
-        return new CustomUserPrincipal(
+        logger.info(
+                "사용자 조회 성공 - userId: {}, email: {}, role: {}",
                 user.getId(),
                 user.getEmail(),
-                user.getPassword(),
-                Collections.singleton(authority));
+                user.getRole().getName(),
+                CONTEXT);
+
+        String roleName = user.getRole().getName();
+        RoleType roleType = RoleType.valueOf(roleName.toUpperCase());
+
+        GrantedAuthority authority =
+                new SimpleGrantedAuthority(roleType.getRoleName().toUpperCase());
+        List<GrantedAuthority> authorities = List.of(authority);
+
+        return new CustomUserPrincipal(
+                user.getId(), user.getEmail(), user.getPassword(), roleType, authorities);
     }
 }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/repository/querydsl/TeamUnionViewDslRepositoryImpl.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/repository/querydsl/TeamUnionViewDslRepositoryImpl.java
@@ -235,7 +235,10 @@ public class TeamUnionViewDslRepositoryImpl extends AbstractQuerydslRepository
     public static <T> List<T> ensureMaxSize(List<T> unionTeams, Integer limit) {
         final boolean hasNext = unionTeams.size() > limit;
         if (hasNext) {
-            log.info("TeamUnionView ensureMaxSize: hasNext true, limit={} → size={}", limit, unionTeams.size());
+            log.info(
+                    "TeamUnionView ensureMaxSize: hasNext true, limit={} → size={}",
+                    limit,
+                    unionTeams.size());
             return unionTeams.subList(0, limit);
         }
         log.info("TeamUnionView ensureMaxSize: hasNext false - size={}", unionTeams.size());

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/service/ProjectTeamService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/service/ProjectTeamService.java
@@ -2,7 +2,6 @@ package backend.techeerzip.domain.projectTeam.service;
 
 import static backend.techeerzip.domain.projectTeam.repository.querydsl.TeamUnionViewDslRepositoryImpl.ensureMaxSize;
 
-import backend.techeerzip.domain.projectTeam.exception.ProjectTeamMainImageException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -51,6 +50,7 @@ import backend.techeerzip.domain.projectTeam.exception.ProjectDuplicateTeamName;
 import backend.techeerzip.domain.projectTeam.exception.ProjectExceededResultImageException;
 import backend.techeerzip.domain.projectTeam.exception.ProjectInvalidProjectMemberException;
 import backend.techeerzip.domain.projectTeam.exception.ProjectTeamDuplicateDeleteUpdateException;
+import backend.techeerzip.domain.projectTeam.exception.ProjectTeamMainImageException;
 import backend.techeerzip.domain.projectTeam.exception.ProjectTeamMissingLeaderException;
 import backend.techeerzip.domain.projectTeam.exception.ProjectTeamMissingUpdateMemberException;
 import backend.techeerzip.domain.projectTeam.exception.ProjectTeamNotFoundException;
@@ -73,7 +73,6 @@ import backend.techeerzip.domain.projectTeam.type.TeamRole;
 import backend.techeerzip.domain.user.entity.User;
 import backend.techeerzip.domain.user.repository.UserRepository;
 import backend.techeerzip.global.entity.StatusCategory;
-import backend.techeerzip.global.logger.CustomLogger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -187,7 +186,8 @@ public class ProjectTeamService {
         final TeamData teamData = request.getTeamData();
         final RecruitCounts recruitCounts = request.getRecruitCounts();
         final List<ProjectMemberInfoRequest> membersInfo = request.getProjectMember();
-        final List<TeamStackInfo.WithName> teamStacksInfo = Optional.ofNullable(request.getTeamStacks()).orElse(List.of());
+        final List<TeamStackInfo.WithName> teamStacksInfo =
+                Optional.ofNullable(request.getTeamStacks()).orElse(List.of());
 
         final boolean isRecruited = checkRecruit(recruitCounts, teamData.getIsRecruited());
         log.info(
@@ -235,7 +235,6 @@ public class ProjectTeamService {
                     teamStacks.stream().map(s -> ProjectTeamStackMapper.toEntity(s, team)).toList();
             teamEntity.addTeamStacks(teamStackEntities);
             log.info("CreateProjectTeam: 팀 스택 엔티티 저장 완료 - count={}", teamStackEntities.size());
-
         }
 
         final List<LeaderInfo> leaders = projectMemberService.getLeaders(team.getId());

--- a/techeerzip/src/main/java/backend/techeerzip/domain/resume/dto/response/ResumeCreateResponse.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/resume/dto/response/ResumeCreateResponse.java
@@ -57,7 +57,7 @@ public class ResumeCreateResponse {
             this.name = user.getName();
             this.nickname = user.getNickname();
             this.profileImage = user.getProfileImage();
-            this.year = user.getYear();
+            this.year = user.getYear() != null ? user.getYear() : -1;
             this.mainPosition = user.getMainPosition();
             this.subPosition = user.getSubPosition();
             this.school = user.getSchool();

--- a/techeerzip/src/main/java/backend/techeerzip/domain/role/entity/RoleType.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/role/entity/RoleType.java
@@ -1,11 +1,11 @@
 package backend.techeerzip.domain.role.entity;
 
 public enum RoleType {
-    ADMIN ("ROLE_ADMIN"),
-    MENTOR ("ROLE_MENTOR"),
-    USER ("ROLE_USER"),
-    COMPANY ("ROLE_COMPANY"),
-    BOOTCAMP ("ROLE_BOOTCAMP");
+    ADMIN("ROLE_ADMIN"),
+    MENTOR("ROLE_MENTOR"),
+    USER("ROLE_USER"),
+    COMPANY("ROLE_COMPANY"),
+    BOOTCAMP("ROLE_BOOTCAMP");
 
     private final String roleName;
 

--- a/techeerzip/src/main/java/backend/techeerzip/domain/role/entity/RoleType.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/role/entity/RoleType.java
@@ -1,0 +1,19 @@
+package backend.techeerzip.domain.role.entity;
+
+public enum RoleType {
+    ADMIN ("ROLE_ADMIN"),
+    MENTOR ("ROLE_MENTOR"),
+    USER ("ROLE_USER"),
+    COMPANY ("ROLE_COMPANY"),
+    BOOTCAMP ("ROLE_BOOTCAMP");
+
+    private final String roleName;
+
+    RoleType(String roleName) {
+        this.roleName = roleName;
+    }
+
+    public String getRoleName() {
+        return roleName;
+    }
+}

--- a/techeerzip/src/main/java/backend/techeerzip/domain/techBloggingChallenge/entity/TechBloggingTerm.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/techBloggingChallenge/entity/TechBloggingTerm.java
@@ -3,9 +3,9 @@ package backend.techeerzip.domain.techBloggingChallenge.entity;
 import java.util.ArrayList;
 import java.util.List;
 
-import backend.techeerzip.domain.techBloggingChallenge.exception.TechBloggingTermParticipantAlreadyExistsException;
 import jakarta.persistence.*;
 
+import backend.techeerzip.domain.techBloggingChallenge.exception.TechBloggingTermParticipantAlreadyExistsException;
 import backend.techeerzip.domain.user.entity.User;
 import backend.techeerzip.global.entity.BaseEntity;
 import lombok.*;
@@ -72,19 +72,21 @@ public class TechBloggingTerm extends BaseEntity {
 
     /**
      * 사용자가 이미 해당 챌린지 기간에 참여했는지 확인합니다.
-     * 
+     *
      * @param user 확인할 사용자
      * @return 이미 참여한 경우 true, 그렇지 않으면 false
      */
     public boolean isUserAlreadyParticipated(User user) {
         return this.participants.stream()
-                .anyMatch(participant -> !participant.isDeleted() &&
-                        participant.getUser().getId().equals(user.getId()));
+                .anyMatch(
+                        participant ->
+                                !participant.isDeleted()
+                                        && participant.getUser().getId().equals(user.getId()));
     }
 
     /**
      * 사용자를 챌린지 기간에 참여시킵니다.
-     * 
+     *
      * @param user 참여시킬 사용자
      * @throws TechBloggingTermParticipantAlreadyExistsException 이미 참여한 사용자인 경우
      */

--- a/techeerzip/src/main/java/backend/techeerzip/domain/techBloggingChallenge/exception/TechBloggingTermParticipantAlreadyExistsException.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/techBloggingChallenge/exception/TechBloggingTermParticipantAlreadyExistsException.java
@@ -1,7 +1,7 @@
 package backend.techeerzip.domain.techBloggingChallenge.exception;
 
-import backend.techeerzip.global.exception.ErrorCode;
 import backend.techeerzip.global.exception.BusinessException;
+import backend.techeerzip.global.exception.ErrorCode;
 
 public class TechBloggingTermParticipantAlreadyExistsException extends BusinessException {
     public TechBloggingTermParticipantAlreadyExistsException() {

--- a/techeerzip/src/main/java/backend/techeerzip/domain/techBloggingChallenge/service/TechBloggingChallengeService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/techBloggingChallenge/service/TechBloggingChallengeService.java
@@ -18,7 +18,6 @@ import backend.techeerzip.domain.techBloggingChallenge.entity.DateRange;
 import backend.techeerzip.domain.techBloggingChallenge.entity.TechBloggingAttendance;
 import backend.techeerzip.domain.techBloggingChallenge.entity.TechBloggingRound;
 import backend.techeerzip.domain.techBloggingChallenge.entity.TechBloggingTerm;
-import backend.techeerzip.domain.techBloggingChallenge.entity.TechBloggingTermParticipant;
 import backend.techeerzip.domain.techBloggingChallenge.entity.TermPeriod;
 import backend.techeerzip.domain.techBloggingChallenge.exception.*;
 import backend.techeerzip.domain.techBloggingChallenge.mapper.TechBloggingChallengeMapper;
@@ -64,33 +63,37 @@ public class TechBloggingChallengeService {
     // 챌린지 기간 조회
     @Transactional(readOnly = true)
     public TermDetailResponse getTerm(Long termId) {
-        TechBloggingTerm term = termRepository
-                .findById(termId)
-                .orElseThrow(() -> new TechBloggingTermNotFoundException());
+        TechBloggingTerm term =
+                termRepository
+                        .findById(termId)
+                        .orElseThrow(() -> new TechBloggingTermNotFoundException());
         return TechBloggingChallengeMapper.toTermDetailResponse(term);
     }
 
     // 챌린지 기간 삭제
     @Transactional
     public void deleteTerm(Long termId) {
-        TechBloggingTerm term = termRepository
-                .findById(termId)
-                .orElseThrow(() -> new TechBloggingTermNotFoundException());
+        TechBloggingTerm term =
+                termRepository
+                        .findById(termId)
+                        .orElseThrow(() -> new TechBloggingTermNotFoundException());
         term.softDelete();
     }
 
     // 단일 회차 생성
     @Transactional
     public RoundDetailResponse createRound(CreateSingleRoundRequest request) {
-        TechBloggingTerm term = termRepository
-                .findById(request.getTermId())
-                .orElseThrow(() -> new TechBloggingTermNotFoundException());
+        TechBloggingTerm term =
+                termRepository
+                        .findById(request.getTermId())
+                        .orElseThrow(() -> new TechBloggingTermNotFoundException());
 
         validateNotPastDate(request.getStartDate());
         validateNoDuplicateRound(term, request.getStartDate(), request.getEndDate());
 
-        TechBloggingRound round = TechBloggingRound.create(
-                request.getStartDate(), request.getEndDate(), request.getSequence(), term);
+        TechBloggingRound round =
+                TechBloggingRound.create(
+                        request.getStartDate(), request.getEndDate(), request.getSequence(), term);
         round = roundRepository.save(round);
         term.addRound(round);
 
@@ -100,11 +103,13 @@ public class TechBloggingChallengeService {
     // 회차 수정
     @Transactional
     public RoundDetailResponse updateRound(UpdateRoundRequest request) {
-        TechBloggingRound round = roundRepository
-                .findById(request.getRoundId())
-                .orElseThrow(() -> new TechBloggingRoundNotFoundException());
+        TechBloggingRound round =
+                roundRepository
+                        .findById(request.getRoundId())
+                        .orElseThrow(() -> new TechBloggingRoundNotFoundException());
 
-        long days = ChronoUnit.DAYS.between(request.getStartDate(), request.getEndDate().plusDays(1));
+        long days =
+                ChronoUnit.DAYS.between(request.getStartDate(), request.getEndDate().plusDays(1));
         if (days < MINIMUM_ROUND_DURATION_DAYS) {
             throw new TechBloggingRoundPeriodTooShortException();
         }
@@ -116,9 +121,10 @@ public class TechBloggingChallengeService {
     // 회차 삭제
     @Transactional
     public void deleteRound(Long roundId) {
-        TechBloggingRound round = roundRepository
-                .findById(roundId)
-                .orElseThrow(() -> new TechBloggingRoundNotFoundException());
+        TechBloggingRound round =
+                roundRepository
+                        .findById(roundId)
+                        .orElseThrow(() -> new TechBloggingRoundNotFoundException());
         round.softDelete();
     }
 
@@ -152,8 +158,7 @@ public class TechBloggingChallengeService {
             round = roundRepository.save(round);
             term.addRound(round);
 
-            if (isLastRound)
-                break;
+            if (isLastRound) break;
             start = roundEnd.plusDays(1);
         }
     }
@@ -191,9 +196,10 @@ public class TechBloggingChallengeService {
     public void applyChallenge(Long userId, ApplyChallengeRequest request) {
         // 1. 해당 Term 조회
         TermPeriod period = TermPeriod.from(request.isFirstHalf());
-        TechBloggingTerm term = termRepository
-                .findByYearAndPeriodAndIsDeletedFalse(request.getYear(), period)
-                .orElseThrow(() -> new TechBloggingTermNotFoundException());
+        TechBloggingTerm term =
+                termRepository
+                        .findByYearAndPeriodAndIsDeletedFalse(request.getYear(), period)
+                        .orElseThrow(() -> new TechBloggingTermNotFoundException());
 
         // 2. 유저 조회
         User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException());
@@ -224,9 +230,10 @@ public class TechBloggingChallengeService {
                             List<Integer> sequence = new ArrayList<>();
                             int totalCount = 0;
                             for (TechBloggingRound round : rounds) {
-                                int attendanceCount = attendanceRepository
-                                        .countByUserAndTechBloggingRoundAndIsDeletedFalse(
-                                                user, round);
+                                int attendanceCount =
+                                        attendanceRepository
+                                                .countByUserAndTechBloggingRoundAndIsDeletedFalse(
+                                                        user, round);
                                 sequence.add(attendanceCount);
                                 totalCount += attendanceCount;
                             }
@@ -245,20 +252,24 @@ public class TechBloggingChallengeService {
         List<TechBloggingRound> rounds = roundRepository.findActiveRoundsOnDate(today);
 
         for (TechBloggingRound round : rounds) {
-            List<User> participants = round.getTerm().getParticipants().stream()
-                    .filter(p -> !p.isDeleted())
-                    .map(p -> p.getUser())
-                    .toList();
+            List<User> participants =
+                    round.getTerm().getParticipants().stream()
+                            .filter(p -> !p.isDeleted())
+                            .map(p -> p.getUser())
+                            .toList();
             for (User user : participants) {
-                java.util.List<Blog> blogs = blogRepository.findByUserAndDateBetweenAndIsDeletedFalse(
-                        user,
-                        round.getStartDate().atStartOfDay(),
-                        round.getEndDate().atTime(23, 59, 59));
+                java.util.List<Blog> blogs =
+                        blogRepository.findByUserAndDateBetweenAndIsDeletedFalse(
+                                user,
+                                round.getStartDate().atStartOfDay(),
+                                round.getEndDate().atTime(23, 59, 59));
                 for (Blog blog : blogs) {
-                    boolean alreadyExists = attendanceRepository.existsByUserAndTechBloggingRoundAndBlog(
-                            user, round, blog);
+                    boolean alreadyExists =
+                            attendanceRepository.existsByUserAndTechBloggingRoundAndBlog(
+                                    user, round, blog);
                     if (!alreadyExists) {
-                        TechBloggingAttendance attendance = new TechBloggingAttendance(user, round, blog);
+                        TechBloggingAttendance attendance =
+                                new TechBloggingAttendance(user, round, blog);
                         attendanceRepository.save(attendance);
                         System.out.printf(
                                 "출석 저장: userId=%d, roundId=%d, blogId=%d\n",
@@ -271,9 +282,10 @@ public class TechBloggingChallengeService {
 
     @Transactional(readOnly = true)
     public TermRoundsSummaryResponse getTermRoundsSummary(Long termId) {
-        TechBloggingTerm term = termRepository
-                .findById(termId)
-                .orElseThrow(() -> new TechBloggingTermNotFoundException());
+        TechBloggingTerm term =
+                termRepository
+                        .findById(termId)
+                        .orElseThrow(() -> new TechBloggingTermNotFoundException());
         if (term.getRounds().isEmpty()) {
             throw new TechBloggingTermNoRoundsException();
         }
@@ -296,14 +308,16 @@ public class TechBloggingChallengeService {
     }
 
     private DateRange calculateTermDateRange(TechBloggingTerm term) {
-        LocalDate startDate = term.getRounds().stream()
-                .map(r -> r.getStartDate())
-                .min(LocalDate::compareTo)
-                .orElse(null);
-        LocalDate endDate = term.getRounds().stream()
-                .map(r -> r.getEndDate())
-                .max(LocalDate::compareTo)
-                .orElse(null);
+        LocalDate startDate =
+                term.getRounds().stream()
+                        .map(r -> r.getStartDate())
+                        .min(LocalDate::compareTo)
+                        .orElse(null);
+        LocalDate endDate =
+                term.getRounds().stream()
+                        .map(r -> r.getEndDate())
+                        .max(LocalDate::compareTo)
+                        .orElse(null);
         return DateRange.of(startDate, endDate);
     }
 
@@ -328,8 +342,9 @@ public class TechBloggingChallengeService {
         List<Long> validBlogIds = attendanceRepository.getValidBlogIds(termId, roundId);
         Blog cursorBlog = validateAndGetCursorBlog(request.cursorId(), validBlogIds);
 
-        List<Blog> blogs = blogRepository.findBlogsForChallenge(
-                validBlogIds, cursorBlog, request.limit() + 1, request.sortBy());
+        List<Blog> blogs =
+                blogRepository.findBlogsForChallenge(
+                        validBlogIds, cursorBlog, request.limit() + 1, request.sortBy());
 
         return TechBloggingChallengeMapper.toBlogChallengeListResponse(blogs, request.limit());
     }
@@ -339,14 +354,16 @@ public class TechBloggingChallengeService {
         LocalDate today = LocalDate.now();
         return termRepository.findByIsDeletedFalse().stream()
                 .filter(
-                        term -> !term.isDeleted()
-                                && term.getRounds().stream()
-                                        .anyMatch(
-                                                round -> !round.isDeleted()
-                                                        && !round.getStartDate()
-                                                                .isAfter(today)
-                                                        && !round.getEndDate()
-                                                                .isBefore(today)))
+                        term ->
+                                !term.isDeleted()
+                                        && term.getRounds().stream()
+                                                .anyMatch(
+                                                        round ->
+                                                                !round.isDeleted()
+                                                                        && !round.getStartDate()
+                                                                                .isAfter(today)
+                                                                        && !round.getEndDate()
+                                                                                .isBefore(today)))
                 .findFirst()
                 .map(term -> term.getId())
                 .orElse(null);
@@ -357,15 +374,17 @@ public class TechBloggingChallengeService {
             LocalDate today = LocalDate.now();
             return termRepository.findByIsDeletedFalse().stream()
                     .filter(
-                            term -> !term.isDeleted()
-                                    && term.getRounds().stream()
-                                            .anyMatch(
-                                                    round -> !round.isDeleted()
-                                                            && !round.getStartDate()
-                                                                    .isAfter(today)
-                                                            && !round.getEndDate()
-                                                                    .isBefore(
-                                                                            today)))
+                            term ->
+                                    !term.isDeleted()
+                                            && term.getRounds().stream()
+                                                    .anyMatch(
+                                                            round ->
+                                                                    !round.isDeleted()
+                                                                            && !round.getStartDate()
+                                                                                    .isAfter(today)
+                                                                            && !round.getEndDate()
+                                                                                    .isBefore(
+                                                                                            today)))
                     .findFirst()
                     .orElseThrow(() -> new TechBloggingTermNotFoundException());
         } else {
@@ -390,9 +409,10 @@ public class TechBloggingChallengeService {
     }
 
     private void validateRoundBelongsToTerm(Long roundId, Long termId) {
-        TechBloggingRound round = roundRepository
-                .findById(roundId)
-                .orElseThrow(() -> new TechBloggingRoundNotFoundException());
+        TechBloggingRound round =
+                roundRepository
+                        .findById(roundId)
+                        .orElseThrow(() -> new TechBloggingRoundNotFoundException());
         if (!round.getTerm().getId().equals(termId)) {
             throw new TechBloggingRoundNotFoundException();
         }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/controller/UserController.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/controller/UserController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import backend.techeerzip.domain.user.dto.request.CreateExternalUserRequest;
 import backend.techeerzip.domain.user.dto.request.CreateUserPermissionRequest;
 import backend.techeerzip.domain.user.dto.request.CreateUserWithResumeRequest;
 import backend.techeerzip.domain.user.dto.request.GetUserProfileListRequest;
@@ -60,6 +61,16 @@ public class UserController implements UserSwagger {
                 "회원가입 요청 처리 완료 - email: {}",
                 createUserWithResumeRequest.getCreateUserRequest().getEmail(),
                 CONTEXT);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping(value = "/signup/external")
+    @Override
+    public ResponseEntity<Void> signupExternal(
+            @RequestBody CreateExternalUserRequest createExternalUserRequest) {
+        logger.info("외부인 회원가입 요청 처리 중 - email: {}", createExternalUserRequest.getEmail());
+        userService.signUpExternal(createExternalUserRequest);
+        logger.info("외부인 회원가입 요청 처리 완료 - email: {}", createExternalUserRequest.getEmail());
         return ResponseEntity.ok().build();
     }
 

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/controller/UserSwagger.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/controller/UserSwagger.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.multipart.MultipartFile;
 
+import backend.techeerzip.domain.user.dto.request.CreateExternalUserRequest;
 import backend.techeerzip.domain.user.dto.request.CreateUserPermissionRequest;
 import backend.techeerzip.domain.user.dto.request.CreateUserWithResumeRequest;
 import backend.techeerzip.domain.user.dto.request.GetUserProfileListRequest;
@@ -40,6 +41,22 @@ public interface UserSwagger {
                                                 implementation = ErrorResponse.class)))
     })
     default ResponseEntity<Void> signup(MultipartFile file, CreateUserWithResumeRequest req) {
+        throw new UnsupportedOperationException("Swagger 전용 인터페이스입니다.");
+    }
+
+    @Operation(summary = "외부인 회원가입", description = "새로운 외부인 회원을 생성합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 회원가입 요청",
+                content =
+                        @io.swagger.v3.oas.annotations.media.Content(
+                                schema =
+                                        @io.swagger.v3.oas.annotations.media.Schema(
+                                                implementation = ErrorResponse.class)))
+    })
+    default ResponseEntity<Void> signupExternal(CreateExternalUserRequest req) {
         throw new UnsupportedOperationException("Swagger 전용 인터페이스입니다.");
     }
 

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/UserDto.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/UserDto.java
@@ -1,7 +1,0 @@
-package backend.techeerzip.domain.user.dto;
-
-public class UserDto {
-    private int userId;
-    private String username;
-    private String password;
-}

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/request/CreateExternalUserRequest.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/request/CreateExternalUserRequest.java
@@ -2,6 +2,7 @@ package backend.techeerzip.domain.user.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import backend.techeerzip.domain.user.entity.JoinReason;
@@ -28,7 +29,7 @@ public class CreateExternalUserRequest {
     @Schema(description = "비밀번호", example = "Passw0rd!")
     private String password;
 
-    @NotBlank
+    @NotNull
     @Schema(description = "가입 동기", example = "BOOTCAMP")
     private JoinReason joinReason;
 }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/request/CreateExternalUserRequest.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/request/CreateExternalUserRequest.java
@@ -1,0 +1,34 @@
+package backend.techeerzip.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import backend.techeerzip.domain.user.entity.JoinReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateExternalUserRequest {
+    @NotBlank
+    @Schema(description = "이름", example = "김테커")
+    private String name;
+
+    @Email
+    @NotBlank
+    @Schema(description = "이메일 주소", example = "user@example.com")
+    private String email;
+
+    @NotBlank
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @Schema(description = "비밀번호", example = "Passw0rd!")
+    private String password;
+
+    @NotBlank
+    @Schema(description = "가입 동기", example = "BOOTCAMP")
+    private JoinReason joinReason;
+}

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/entity/JoinReason.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/entity/JoinReason.java
@@ -1,0 +1,6 @@
+package backend.techeerzip.domain.user.entity;
+
+public enum JoinReason {
+    BOOTCAMP,
+    COMPANY
+}

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/entity/User.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/entity/User.java
@@ -97,28 +97,26 @@ public class User extends BaseEntity {
     @Column(length = 200)
     private String nickname;
 
-    @Column(nullable = false)
-    private Integer year;
+    @Column private Integer year;
 
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
-    private boolean isLft;
+    @Column private boolean isLft;
 
-    @Column(nullable = false, length = 500)
+    @Column(length = 500)
     private String githubUrl;
 
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String mainPosition;
 
     @Column(length = 100)
     private String subPosition;
 
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String school;
 
-    @Column(nullable = false, length = 1000)
+    @Column(length = 1000)
     private String profileImage;
 
     @JdbcTypeCode(SqlTypes.ARRAY)

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/mapper/UserMapper.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/mapper/UserMapper.java
@@ -23,8 +23,8 @@ public class UserMapper {
                 .mediumUrl(user.getMediumUrl())
                 .velogUrl(user.getVelogUrl())
                 .tistoryUrl(user.getTistoryUrl())
-                .isLft(user.isLft())
-                .year(user.getYear())
+                .isLft(Boolean.TRUE.equals(user.isLft()))
+                .year(user.getYear() != null ? user.getYear() : -1)
                 .stack(user.getStack())
                 .projectTeams(
                         user.getProjectMembers().stream()

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/service/UserService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/service/UserService.java
@@ -1,5 +1,27 @@
 package backend.techeerzip.domain.user.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
 import backend.techeerzip.domain.auth.exception.AuthNotTecheerException;
 import backend.techeerzip.domain.auth.exception.AuthNotVerifiedEmailException;
 import backend.techeerzip.domain.auth.service.AuthService;
@@ -43,27 +65,8 @@ import backend.techeerzip.domain.userExperience.exception.UserExperienceNotFound
 import backend.techeerzip.domain.userExperience.repository.UserExperienceRepository;
 import backend.techeerzip.global.entity.StatusCategory;
 import backend.techeerzip.global.logger.CustomLogger;
-import jakarta.servlet.http.HttpServletResponse;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseCookie;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/service/UserService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/service/UserService.java
@@ -155,8 +155,10 @@ public class UserService {
             existingUser.setVelogUrl(createUserRequest.getVelogUrl());
             existingUser.setMediumUrl(createUserRequest.getMediumUrl());
             existingUser.setSchool(createUserRequest.getSchool());
-            existingUser.setYear(createUserRequest.getYear());
-            existingUser.setLft(createUserRequest.getIsLft());
+            existingUser.setLft(
+                    createUserRequest.getIsLft() != null ? createUserRequest.getIsLft() : false);
+            existingUser.setYear(
+                    createUserRequest.getYear() != null ? createUserRequest.getYear() : -1);
             existingUser.setProfileImage(profileImage);
             existingUser.setAuth(true);
             existingUser.setRole(defaultRole);
@@ -531,14 +533,23 @@ public class UserService {
                         : "year";
 
         List<User> users =
-                userRepository.findUsersWithCursor(
-                        getUserProfileListRequest.getCursorId(),
-                        getUserProfileListRequest.getPosition(),
-                        getUserProfileListRequest.getYear(),
-                        getUserProfileListRequest.getUniversity(),
-                        getUserProfileListRequest.getGrade(),
-                        limit,
-                        sortBy);
+                userRepository
+                        .findUsersWithCursor(
+                                getUserProfileListRequest.getCursorId(),
+                                getUserProfileListRequest.getPosition(),
+                                getUserProfileListRequest.getYear(),
+                                getUserProfileListRequest.getUniversity(),
+                                getUserProfileListRequest.getGrade(),
+                                limit + 1,
+                                sortBy)
+                        .stream()
+                        .filter(
+                                user -> {
+                                    Long roleId =
+                                            user.getRole() != null ? user.getRole().getId() : null;
+                                    return roleId != null && roleId >= 0 && roleId <= 3;
+                                })
+                        .collect(Collectors.toList());
 
         boolean hasNext = users.size() > limit;
         if (hasNext) {

--- a/techeerzip/src/main/java/backend/techeerzip/global/config/SecurityConfig.java
+++ b/techeerzip/src/main/java/backend/techeerzip/global/config/SecurityConfig.java
@@ -50,13 +50,50 @@ public class SecurityConfig {
         http.authorizeHttpRequests(
                         auth ->
                                 auth
-                                        // jwt 인증 필요 없는 엔드 포인트
+                                        // Admin
+                                        .requestMatchers("/api/v3/users/permission/**")
+                                        .hasRole("ADMIN")
+
+                                        // Admin, Mentor, User
+                                        .requestMatchers(HttpMethod.GET, "/api/v3/users")
+                                        .hasAnyRole("ADMIN", "MENTOR", "USER")
+                                        .requestMatchers(
+                                                HttpMethod.POST, "/api/v3/blogs", "/api/v3/events")
+                                        .hasAnyRole("ADMIN", "MENTOR", "USER")
+                                        .requestMatchers(
+                                                "/api/v3/sessions/**",
+                                                "/api/v3/tech-blogging/**",
+                                                "/api/v3/projectTeams/**",
+                                                "/api/v3/studyTeams/**")
+                                        .hasAnyRole("ADMIN", "MENTOR", "USER")
+
+                                        // Admin, Mentor, User, Company
+                                        .requestMatchers(
+                                                HttpMethod.GET,
+                                                "/api/v3/studyTeams/*",
+                                                "/api/v3/projectTeams/*",
+                                                "/api/v3/users/*")
+                                        .hasAnyRole("ADMIN", "MENTOR", "USER", "COMPANY")
+                                        .requestMatchers("/api/v3/resumes/**")
+                                        .hasAnyRole("ADMIN", "MENTOR", "USER", "COMPANY")
+
+                                        // Admin, Mentor, User, Company, Bootcamp
+                                        .requestMatchers(
+                                                "/api/v3/events/**",
+                                                "/api/v3/bookmarks",
+                                                "/api/v3/likes")
+                                        .hasAnyRole(
+                                                "ADMIN", "MENTOR", "USER", "COMPANY", "BOOTCAMP")
+
+                                        // jwt 인증 필요 없는 엔드 포인트 (GUEST 포함)
                                         .requestMatchers(
                                                 "/api/v3/auth/email",
                                                 "/api/v3/auth/code",
                                                 "/api/v3/auth/login",
                                                 "/api/v3/users/signup",
-                                                "/api/v3/users/findPwd")
+                                                "/api/v3/users/signup/external",
+                                                "/api/v3/users/findPwd",
+                                                "/api/v3/blogs/**")
                                         .permitAll()
                                         // 블로그 GET 요청만 허용
                                         .requestMatchers(HttpMethod.GET, "/api/v3/blogs/**")

--- a/techeerzip/src/main/java/backend/techeerzip/global/config/SecurityConfig.java
+++ b/techeerzip/src/main/java/backend/techeerzip/global/config/SecurityConfig.java
@@ -86,14 +86,15 @@ public class SecurityConfig {
                                                 "ADMIN", "MENTOR", "USER", "COMPANY", "BOOTCAMP")
 
                                         // jwt 인증 필요 없는 엔드 포인트 (GUEST 포함)
+                                        .requestMatchers(HttpMethod.GET, "/api/v3/blogs/**")
+                                        .permitAll()
                                         .requestMatchers(
                                                 "/api/v3/auth/email",
                                                 "/api/v3/auth/code",
                                                 "/api/v3/auth/login",
                                                 "/api/v3/users/signup",
                                                 "/api/v3/users/signup/external",
-                                                "/api/v3/users/findPwd",
-                                                "/api/v3/blogs/**")
+                                                "/api/v3/users/findPwd")
                                         .permitAll()
                                         // 블로그 GET 요청만 허용
                                         .requestMatchers(HttpMethod.GET, "/api/v3/blogs/**")

--- a/techeerzip/src/main/java/backend/techeerzip/global/exception/ErrorCode.java
+++ b/techeerzip/src/main/java/backend/techeerzip/global/exception/ErrorCode.java
@@ -1,19 +1,18 @@
 package backend.techeerzip.global.exception;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-        // Common
-        INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "Invalid Input Value"),
-        METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "Method Not Allowed"),
-        INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "Internal Server Error"),
-        INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "Invalid Type Value"),
-        HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "Access is Denied"),
-        INVALID_CURSOR_ID(HttpStatus.BAD_REQUEST, "C006", "유효하지 않은 커서 ID입니다."),
-        EXCEEDED_RESULT_IMAGE(HttpStatus.BAD_REQUEST, "CT06", "결과 이미지는 10개까지만 등록 가능합니다."),
+    // Common
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "Invalid Input Value"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "Method Not Allowed"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "Internal Server Error"),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "Invalid Type Value"),
+    HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "접근 권한이 없습니다."),
+    INVALID_CURSOR_ID(HttpStatus.BAD_REQUEST, "C006", "유효하지 않은 커서 ID입니다."),
+    EXCEEDED_RESULT_IMAGE(HttpStatus.BAD_REQUEST, "CT06", "결과 이미지는 10개까지만 등록 가능합니다."),
 
         // Auth
         AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A001", "이메일 또는 비밀번호가 올바르지 않습니다."),

--- a/techeerzip/src/main/java/backend/techeerzip/global/exception/ErrorCode.java
+++ b/techeerzip/src/main/java/backend/techeerzip/global/exception/ErrorCode.java
@@ -15,150 +15,150 @@ public enum ErrorCode {
     INVALID_CURSOR_ID(HttpStatus.BAD_REQUEST, "C006", "유효하지 않은 커서 ID입니다."),
     EXCEEDED_RESULT_IMAGE(HttpStatus.BAD_REQUEST, "CT06", "결과 이미지는 10개까지만 등록 가능합니다."),
 
-        // Auth
-        AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A001", "이메일 또는 비밀번호가 올바르지 않습니다."),
-        AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 JWT 토큰입니다."),
-        AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "JWT 토큰이 만료 되었습니다."),
-        AUTH_MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "JWT 토큰이 필요합니다."),
-        AUTH_EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "A005", "이메일 인증 코드 전송이 실패했습니다."),
-        AUTH_INVALID_EMAIL_CODE(HttpStatus.BAD_REQUEST, "A006", "잘못된 이메일 인증 코드입니다."),
-        AUTH_NOT_VERIFIED_EMAIL(HttpStatus.UNAUTHORIZED, "A007", "이메일 인증이 완료되지 않았습니다."),
-        AUTH_NOT_TECHEER(HttpStatus.BAD_REQUEST, "A008", "테커가 아닌 사용자입니다."),
+    // Auth
+    AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A001", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 JWT 토큰입니다."),
+    AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "JWT 토큰이 만료 되었습니다."),
+    AUTH_MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "JWT 토큰이 필요합니다."),
+    AUTH_EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "A005", "이메일 인증 코드 전송이 실패했습니다."),
+    AUTH_INVALID_EMAIL_CODE(HttpStatus.BAD_REQUEST, "A006", "잘못된 이메일 인증 코드입니다."),
+    AUTH_NOT_VERIFIED_EMAIL(HttpStatus.UNAUTHORIZED, "A007", "이메일 인증이 완료되지 않았습니다."),
+    AUTH_NOT_TECHEER(HttpStatus.BAD_REQUEST, "A008", "테커가 아닌 사용자입니다."),
 
-        // User
-        USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
-        USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "U003", "이미 가입한 이메일입니다."),
-        USER_NOT_RESUME(HttpStatus.BAD_REQUEST, "U004", "이력서 파일이 없습니다."),
-        USER_UNAUTHORIZED_ADMIN(HttpStatus.FORBIDDEN, "U005", "권한이 없는 사용자입니다."),
-        USER_PROFILE_IMG_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "U006", "프로필 이미지를 가져오지 못했습니다."),
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "U003", "이미 가입한 이메일입니다."),
+    USER_NOT_RESUME(HttpStatus.BAD_REQUEST, "U004", "이력서 파일이 없습니다."),
+    USER_UNAUTHORIZED_ADMIN(HttpStatus.FORBIDDEN, "U005", "권한이 없는 사용자입니다."),
+    USER_PROFILE_IMG_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "U006", "프로필 이미지를 가져오지 못했습니다."),
 
-        // UserExperience
-        USER_EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "UE001", "해당 경력을 찾을 수 없습니다."),
+    // UserExperience
+    USER_EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "UE001", "해당 경력을 찾을 수 없습니다."),
 
-        // Blog
-        BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "블로그를 찾을 수 없습니다."),
-        BLOG_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "B002", "이미 존재하는 블로그입니다."),
-        BLOG_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "B003", "블로그에 접근할 권한이 없습니다."),
-        BLOG_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "B004", "블로그 요청이 유효하지 않습니다."),
-        BLOG_CRAWLING_ERROR(HttpStatus.BAD_REQUEST, "B005", "블로그 크롤링 중 오류가 발생했습니다."),
-        BLOG_INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "B006", "잘못된 날짜 형식입니다."),
-        BLOG_EMPTY_DATE(HttpStatus.BAD_REQUEST, "B007", "날짜가 비어있습니다."),
-        BLOG_EMPTY_POSTS(HttpStatus.BAD_REQUEST, "B008", "크롤링 포스트 목록이 비어있습니다."),
-        BLOG_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "B009", "블로그 작성자를 찾을 수 없습니다."),
+    // Blog
+    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "블로그를 찾을 수 없습니다."),
+    BLOG_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "B002", "이미 존재하는 블로그입니다."),
+    BLOG_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "B003", "블로그에 접근할 권한이 없습니다."),
+    BLOG_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "B004", "블로그 요청이 유효하지 않습니다."),
+    BLOG_CRAWLING_ERROR(HttpStatus.BAD_REQUEST, "B005", "블로그 크롤링 중 오류가 발생했습니다."),
+    BLOG_INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "B006", "잘못된 날짜 형식입니다."),
+    BLOG_EMPTY_DATE(HttpStatus.BAD_REQUEST, "B007", "날짜가 비어있습니다."),
+    BLOG_EMPTY_POSTS(HttpStatus.BAD_REQUEST, "B008", "크롤링 포스트 목록이 비어있습니다."),
+    BLOG_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "B009", "블로그 작성자를 찾을 수 없습니다."),
 
-        // Bookmark
-        BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BM001", "Bookmark not found"),
-        BOOKMARK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "BM002", "Bookmark already exists"),
-        BOOKMARK_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "BM003", "Unauthorized to access this bookmark"),
+    // Bookmark
+    BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BM001", "Bookmark not found"),
+    BOOKMARK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "BM002", "Bookmark already exists"),
+    BOOKMARK_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "BM003", "Unauthorized to access this bookmark"),
 
-        // Team
-        TEAM_INVALID_RECRUIT_NUM(HttpStatus.BAD_REQUEST, "ST004", "모집 인원이 음수 입니다."),
-        TEAM_INVALID_ACTIVE_REQUESTER(HttpStatus.BAD_REQUEST, "PM003", "팀 멤버만 접근할 수 있습니다."),
-        TEAM_INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "PM003", "유효하지 않은 팀 정렬 방식 입니다.."),
-        TEAM_INVALID_SLICE_QUERY(HttpStatus.BAD_REQUEST, "PM003", "유효하지 않은 팀 정렬 쿼리 입니다.."),
+    // Team
+    TEAM_INVALID_RECRUIT_NUM(HttpStatus.BAD_REQUEST, "ST004", "모집 인원이 음수 입니다."),
+    TEAM_INVALID_ACTIVE_REQUESTER(HttpStatus.BAD_REQUEST, "PM003", "팀 멤버만 접근할 수 있습니다."),
+    TEAM_INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "PM003", "유효하지 않은 팀 정렬 방식 입니다.."),
+    TEAM_INVALID_SLICE_QUERY(HttpStatus.BAD_REQUEST, "PM003", "유효하지 않은 팀 정렬 쿼리 입니다.."),
 
-        // ==== ProjectMember ====
-        PROJECT_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PM001", "존재하지 않는 프로젝트 멤버입니다."),
-        PROJECT_MEMBER_INVALID_TEAM_ROLE(HttpStatus.BAD_REQUEST, "PM002", "프로젝트 멤버의 팀 역할이 유효하지 않습니다."),
-        PROJECT_MEMBER_APPLICATION_EXISTS(HttpStatus.BAD_REQUEST, "PM004", "이미 해당 프로젝트에 지원하셨습니다."),
-        PROJECT_MEMBER_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "PM005", "이미 해당 프로젝트에서 활동 중인 멤버입니다."),
-        PROJECT_MEMBER_NOT_APPLICANT(HttpStatus.BAD_REQUEST, "PM006", "해당 프로젝트 지원자가 아닙니다."),
+    // ==== ProjectMember ====
+    PROJECT_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PM001", "존재하지 않는 프로젝트 멤버입니다."),
+    PROJECT_MEMBER_INVALID_TEAM_ROLE(HttpStatus.BAD_REQUEST, "PM002", "프로젝트 멤버의 팀 역할이 유효하지 않습니다."),
+    PROJECT_MEMBER_APPLICATION_EXISTS(HttpStatus.BAD_REQUEST, "PM004", "이미 해당 프로젝트에 지원하셨습니다."),
+    PROJECT_MEMBER_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "PM005", "이미 해당 프로젝트에서 활동 중인 멤버입니다."),
+    PROJECT_MEMBER_NOT_APPLICANT(HttpStatus.BAD_REQUEST, "PM006", "해당 프로젝트 지원자가 아닙니다."),
 
-        // ==== ProjectTeam ====
-        PROJECT_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "PT001", "프로젝트 팀을 찾을 수 없습니다."),
-        PROJECT_TEAM_MAIN_IMAGE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "PT002", "메인 이미지를 확인해주세요."),
-        PROJECT_TEAM_MISSING_LEADER(HttpStatus.BAD_REQUEST, "PT003", "프로젝트 팀 리더가 존재하지 않습니다."),
-        PROJECT_TEAM_MISSING_MAIN_IMAGE(HttpStatus.BAD_REQUEST, "PT004", "메인 이미지가 존재하지 않습니다."),
-        PROJECT_TEAM_DUPLICATE_TEAM_NAME(HttpStatus.CONFLICT, "PT005", "존재하는 프로젝트 이름입니다."),
-        PROJECT_TEAM_DUPLICATE_DELETE_UPDATE(
-                        HttpStatus.CONFLICT, "PT006", "프로젝트 삭제 멤버와 업데이트 멤버가 중복됩니다."),
-        PROJECT_TEAM_INVALID_TEAM_STACK(HttpStatus.BAD_REQUEST, "PT007", "팀 스택이 유효하지 않습니다."),
-        PROJECT_TEAM_POSITION_CLOSED(HttpStatus.BAD_REQUEST, "PT008", "모집하는 포지션이 아닙니다."),
-        PROJECT_TEAM_MISSING_UPDATE_MEMBER(
-                        HttpStatus.BAD_REQUEST, "PT009", "프로젝트 팀 멤버 업데이트에 누락된 인원이 존재합니다."),
-        PROJECT_TEAM_RECRUITMENT_CLOSED(HttpStatus.BAD_REQUEST, "PT010", "프로젝트 팀 모집이 종료되었습니다."),
-        PROJECT_TEAM_INVALID_TEAM_ROLE(HttpStatus.BAD_REQUEST, "PT011", "유효하지 않은 팀 역할입니다."),
-        PROJECT_TEAM_INVALID_UPDATE_MEMBER(HttpStatus.BAD_REQUEST, "PT012", "업데이트 멤버가 유효하지 않습니다."),
-        PROJECT_TEAM_INVALID_APPLICANT(HttpStatus.BAD_REQUEST, "PT013", "유효하지 않은 지원자입니다."),
-        PROJECT_TEAM_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "PT015", "이미 승인된 프로젝트 멤버입니다."),
-        PROJECT_TEAM_INVALID_DELETE_IMAGE(HttpStatus.BAD_REQUEST, "PT016", "삭제하는 결과이미지가 유효하지 않습니다."),
-        PROJECT_TEAM_INVALID_PROJECT_MEMBER(HttpStatus.BAD_REQUEST, "PT017", "프로젝트 멤버가 유효하지 않습니다."),
+    // ==== ProjectTeam ====
+    PROJECT_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "PT001", "프로젝트 팀을 찾을 수 없습니다."),
+    PROJECT_TEAM_MAIN_IMAGE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "PT002", "메인 이미지를 확인해주세요."),
+    PROJECT_TEAM_MISSING_LEADER(HttpStatus.BAD_REQUEST, "PT003", "프로젝트 팀 리더가 존재하지 않습니다."),
+    PROJECT_TEAM_MISSING_MAIN_IMAGE(HttpStatus.BAD_REQUEST, "PT004", "메인 이미지가 존재하지 않습니다."),
+    PROJECT_TEAM_DUPLICATE_TEAM_NAME(HttpStatus.CONFLICT, "PT005", "존재하는 프로젝트 이름입니다."),
+    PROJECT_TEAM_DUPLICATE_DELETE_UPDATE(
+            HttpStatus.CONFLICT, "PT006", "프로젝트 삭제 멤버와 업데이트 멤버가 중복됩니다."),
+    PROJECT_TEAM_INVALID_TEAM_STACK(HttpStatus.BAD_REQUEST, "PT007", "팀 스택이 유효하지 않습니다."),
+    PROJECT_TEAM_POSITION_CLOSED(HttpStatus.BAD_REQUEST, "PT008", "모집하는 포지션이 아닙니다."),
+    PROJECT_TEAM_MISSING_UPDATE_MEMBER(
+            HttpStatus.BAD_REQUEST, "PT009", "프로젝트 팀 멤버 업데이트에 누락된 인원이 존재합니다."),
+    PROJECT_TEAM_RECRUITMENT_CLOSED(HttpStatus.BAD_REQUEST, "PT010", "프로젝트 팀 모집이 종료되었습니다."),
+    PROJECT_TEAM_INVALID_TEAM_ROLE(HttpStatus.BAD_REQUEST, "PT011", "유효하지 않은 팀 역할입니다."),
+    PROJECT_TEAM_INVALID_UPDATE_MEMBER(HttpStatus.BAD_REQUEST, "PT012", "업데이트 멤버가 유효하지 않습니다."),
+    PROJECT_TEAM_INVALID_APPLICANT(HttpStatus.BAD_REQUEST, "PT013", "유효하지 않은 지원자입니다."),
+    PROJECT_TEAM_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "PT015", "이미 승인된 프로젝트 멤버입니다."),
+    PROJECT_TEAM_INVALID_DELETE_IMAGE(HttpStatus.BAD_REQUEST, "PT016", "삭제하는 결과이미지가 유효하지 않습니다."),
+    PROJECT_TEAM_INVALID_PROJECT_MEMBER(HttpStatus.BAD_REQUEST, "PT017", "프로젝트 멤버가 유효하지 않습니다."),
 
-        // Resume
-        RESUME_NOT_FOUND(HttpStatus.NOT_FOUND, "RS001", "이력서를 찾을 수 없습니다."),
-        RESUME_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "RS002", "이력서에 대한 권한이 없습니다."),
-        RESUME_INVALID_TYPE(HttpStatus.BAD_REQUEST, "RS003", "유효하지 않은 이력서 타입입니다. PDF 형식만 가능합니다."),
+    // Resume
+    RESUME_NOT_FOUND(HttpStatus.NOT_FOUND, "RS001", "이력서를 찾을 수 없습니다."),
+    RESUME_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "RS002", "이력서에 대한 권한이 없습니다."),
+    RESUME_INVALID_TYPE(HttpStatus.BAD_REQUEST, "RS003", "유효하지 않은 이력서 타입입니다. PDF 형식만 가능합니다."),
 
-        // Session
-        SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SS001", "해당 세션을 찾을 수 없습니다"),
-        SESSION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SS002", "해당 세션이 이미 존재합니다."),
-        SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "SS003", "해당 세션에 대한 권한이 없습니다."),
+    // Session
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SS001", "해당 세션을 찾을 수 없습니다"),
+    SESSION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "SS002", "해당 세션이 이미 존재합니다."),
+    SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "SS003", "해당 세션에 대한 권한이 없습니다."),
 
-        // ==== StudyMember ====
-        STUDY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "SM001", "스터디 멤버를 찾을 수 없습니다."),
-        STUDY_MEMBER_BAD_REQUEST(HttpStatus.BAD_REQUEST, "SM002", "유효하지 않은 요청입니다."),
-        STUDY_MEMBER_IS_ACTIVE_MEMBER(HttpStatus.CONFLICT, "SM003", "이미 활동 중인 스터디 멤버입니다."),
-        STUDY_MEMBER_INVALID_TEAM_MEMBER(HttpStatus.BAD_REQUEST, "SM004", "유효하지 않은 스터디 멤버입니다."),
+    // ==== StudyMember ====
+    STUDY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "SM001", "스터디 멤버를 찾을 수 없습니다."),
+    STUDY_MEMBER_BAD_REQUEST(HttpStatus.BAD_REQUEST, "SM002", "유효하지 않은 요청입니다."),
+    STUDY_MEMBER_IS_ACTIVE_MEMBER(HttpStatus.CONFLICT, "SM003", "이미 활동 중인 스터디 멤버입니다."),
+    STUDY_MEMBER_INVALID_TEAM_MEMBER(HttpStatus.BAD_REQUEST, "SM004", "유효하지 않은 스터디 멤버입니다."),
 
-        // ==== StudyTeam ====
-        STUDY_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "ST001", "요청한 스터디 팀을 찾을 수 없습니다."),
-        STUDY_TEAM_BAD_REQUEST(HttpStatus.BAD_REQUEST, "ST002", "유효하지 않은 요청입니다."),
-        STUDY_TEAM_DUPLICATE_TEAM_NAME(HttpStatus.CONFLICT, "ST003", "존재하는 스터디 이름입니다."),
-        STUDY_TEAM_MISSING_LEADER(HttpStatus.BAD_REQUEST, "ST005", "스터디 팀 리더가 존재하지 않습니다."),
-        STUDY_TEAM_INVALID_UPDATE_MEMBER(HttpStatus.BAD_REQUEST, "ST006", "스터디 업데이트 멤버가 유효하지 않습니다."),
-        STUDY_TEAM_ALREADY_ACTIVE_MEMBER(HttpStatus.BAD_REQUEST, "ST007", "이미 활동중인 스터디 멤버입니다."),
-        STUDY_TEAM_ALREADY_REJECT_MEMBER(HttpStatus.BAD_REQUEST, "ST008", "이미 거절된 스터디 팀 지원자 입니다."),
-        STUDY_TEAM_INVALID_APPLICANT(HttpStatus.BAD_REQUEST, "ST009", "유효한 스터디 팀 지원자가 아닙니다."),
-        STUDY_TEAM_INVALID_USER(HttpStatus.BAD_REQUEST, "ST010", "유효한 사용자가 아닙니다."),
-        STUDY_TEAM_NOT_ACTIVE_MEMBER(HttpStatus.BAD_REQUEST, "ST011", "스터디 팀 활동 중인 멤버가 아닙니다."),
-        STUDY_TEAM_DUPLICATE_DELETE_UPDATE(
-                        HttpStatus.BAD_REQUEST, "ST012", "스터디 삭제 멤버와 업데이트 멤버가 중복됩니다."),
-        STUDY_TEAM_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "ST013", "이미 지원한 팀입니다."),
-        STUDY_TEAM_CLOSED_RECRUIT(HttpStatus.BAD_REQUEST, "ST014", "모집이 종료된 스터디입니다."),
+    // ==== StudyTeam ====
+    STUDY_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "ST001", "요청한 스터디 팀을 찾을 수 없습니다."),
+    STUDY_TEAM_BAD_REQUEST(HttpStatus.BAD_REQUEST, "ST002", "유효하지 않은 요청입니다."),
+    STUDY_TEAM_DUPLICATE_TEAM_NAME(HttpStatus.CONFLICT, "ST003", "존재하는 스터디 이름입니다."),
+    STUDY_TEAM_MISSING_LEADER(HttpStatus.BAD_REQUEST, "ST005", "스터디 팀 리더가 존재하지 않습니다."),
+    STUDY_TEAM_INVALID_UPDATE_MEMBER(HttpStatus.BAD_REQUEST, "ST006", "스터디 업데이트 멤버가 유효하지 않습니다."),
+    STUDY_TEAM_ALREADY_ACTIVE_MEMBER(HttpStatus.BAD_REQUEST, "ST007", "이미 활동중인 스터디 멤버입니다."),
+    STUDY_TEAM_ALREADY_REJECT_MEMBER(HttpStatus.BAD_REQUEST, "ST008", "이미 거절된 스터디 팀 지원자 입니다."),
+    STUDY_TEAM_INVALID_APPLICANT(HttpStatus.BAD_REQUEST, "ST009", "유효한 스터디 팀 지원자가 아닙니다."),
+    STUDY_TEAM_INVALID_USER(HttpStatus.BAD_REQUEST, "ST010", "유효한 사용자가 아닙니다."),
+    STUDY_TEAM_NOT_ACTIVE_MEMBER(HttpStatus.BAD_REQUEST, "ST011", "스터디 팀 활동 중인 멤버가 아닙니다."),
+    STUDY_TEAM_DUPLICATE_DELETE_UPDATE(
+            HttpStatus.BAD_REQUEST, "ST012", "스터디 삭제 멤버와 업데이트 멤버가 중복됩니다."),
+    STUDY_TEAM_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "ST013", "이미 지원한 팀입니다."),
+    STUDY_TEAM_CLOSED_RECRUIT(HttpStatus.BAD_REQUEST, "ST014", "모집이 종료된 스터디입니다."),
 
-        // Stack
-        STACK_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "Stack not found"),
-        STACK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "S002", "Stack already exists"),
-        STACK_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "S003", "Unauthorized to access this stack"),
+    // Stack
+    STACK_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "Stack not found"),
+    STACK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "S002", "Stack already exists"),
+    STACK_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "S003", "Unauthorized to access this stack"),
 
-        // Redis
-        REDIS_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "R001", "Redis connection error"),
-        REDIS_MESSAGE_PROCESSING_ERROR(
-                        HttpStatus.INTERNAL_SERVER_ERROR, "R002", "Redis message processing error"),
-        REDIS_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "R003", "Redis task not found"),
+    // Redis
+    REDIS_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "R001", "Redis connection error"),
+    REDIS_MESSAGE_PROCESSING_ERROR(
+            HttpStatus.INTERNAL_SERVER_ERROR, "R002", "Redis message processing error"),
+    REDIS_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "R003", "Redis task not found"),
 
-        // Role
-        ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "RL001", "해당 권한을 찾을 수 없습니다."),
+    // Role
+    ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "RL001", "해당 권한을 찾을 수 없습니다."),
 
-        // Event
-        EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "E001", "이벤트를 찾을 수 없습니다."),
-        EVENT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E002", "이벤트에 대한 권한이 없습니다."),
+    // Event
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "E001", "이벤트를 찾을 수 없습니다."),
+    EVENT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E002", "이벤트에 대한 권한이 없습니다."),
 
-        // TechBloggingRound
-        ROUND_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "TBR001", "이미 해당 연도/반기의 챌린지 회차가 존재합니다."),
-        ROUND_PERIOD_TOO_SHORT(HttpStatus.BAD_REQUEST, "TBR002", "회차 기간은 최소 2주(14일) 이상이어야 합니다."),
-        ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "TBR003", "존재하지 않는 챌린지 회차입니다."),
-        ROUND_PAST_DATE(HttpStatus.BAD_REQUEST, "TBR004", "과거의 회차는 생성할 수 없습니다."),
-        ROUND_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "TBR005", "종료 날짜는 시작 날짜보다 이후여야 합니다."),
-        ROUND_INFINITE_LOOP(HttpStatus.BAD_REQUEST, "TBR006", "라운드 생성 중 무한 루프가 감지되었습니다. 입력값을 확인하세요."),
-        TECH_BLOGGING_TERM_ALREADY_EXISTS(
-                        HttpStatus.BAD_REQUEST, "TBT001", "이미 해당 연도/반기의 챌린지 기간이 존재합니다."),
-        TECH_BLOGGING_TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TBT002", "존재하지 않는 챌린지 기간입니다."),
-        TECH_BLOGGING_TERM_ALREADY_JOINED(HttpStatus.CONFLICT, "TBT003", "이미 해당 챌린지에 참여한 유저입니다."),
-        TECH_BLOGGING_TERM_NO_ROUNDS(HttpStatus.NOT_FOUND, "TBT004", "해당 챌린지 기간에 회차가 존재하지 않습니다."),
-        TECH_BLOGGING_TERM_REQUIRED(HttpStatus.BAD_REQUEST, "TBT005", "챌린지 기간(termId)을 함께 입력해주세요."),
+    // TechBloggingRound
+    ROUND_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "TBR001", "이미 해당 연도/반기의 챌린지 회차가 존재합니다."),
+    ROUND_PERIOD_TOO_SHORT(HttpStatus.BAD_REQUEST, "TBR002", "회차 기간은 최소 2주(14일) 이상이어야 합니다."),
+    ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "TBR003", "존재하지 않는 챌린지 회차입니다."),
+    ROUND_PAST_DATE(HttpStatus.BAD_REQUEST, "TBR004", "과거의 회차는 생성할 수 없습니다."),
+    ROUND_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "TBR005", "종료 날짜는 시작 날짜보다 이후여야 합니다."),
+    ROUND_INFINITE_LOOP(HttpStatus.BAD_REQUEST, "TBR006", "라운드 생성 중 무한 루프가 감지되었습니다. 입력값을 확인하세요."),
+    TECH_BLOGGING_TERM_ALREADY_EXISTS(
+            HttpStatus.BAD_REQUEST, "TBT001", "이미 해당 연도/반기의 챌린지 기간이 존재합니다."),
+    TECH_BLOGGING_TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TBT002", "존재하지 않는 챌린지 기간입니다."),
+    TECH_BLOGGING_TERM_ALREADY_JOINED(HttpStatus.CONFLICT, "TBT003", "이미 해당 챌린지에 참여한 유저입니다."),
+    TECH_BLOGGING_TERM_NO_ROUNDS(HttpStatus.NOT_FOUND, "TBT004", "해당 챌린지 기간에 회차가 존재하지 않습니다."),
+    TECH_BLOGGING_TERM_REQUIRED(HttpStatus.BAD_REQUEST, "TBT005", "챌린지 기간(termId)을 함께 입력해주세요."),
 
-        // S3
-        S3_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "S300", "S3 업로드 요청이 유효하지 않습니다."),
-        S3_DELETE_FAIL(HttpStatus.BAD_REQUEST, "S301", "S3 삭제 요청이 유효하지 않습니다.");
+    // S3
+    S3_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "S300", "S3 업로드 요청이 유효하지 않습니다."),
+    S3_DELETE_FAIL(HttpStatus.BAD_REQUEST, "S301", "S3 삭제 요청이 유효하지 않습니다.");
 
-        private final HttpStatus status;
-        private final String code;
-        private final String message;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 
-        ErrorCode(HttpStatus status, String code, String message) {
-                this.status = status;
-                this.code = code;
-                this.message = message;
-        }
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
 }

--- a/techeerzip/src/main/java/backend/techeerzip/global/exception/ErrorCode.java
+++ b/techeerzip/src/main/java/backend/techeerzip/global/exception/ErrorCode.java
@@ -1,7 +1,8 @@
 package backend.techeerzip.global.exception;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public enum ErrorCode {

--- a/techeerzip/src/main/java/backend/techeerzip/infra/googleDrive/service/GoogleDriveService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/infra/googleDrive/service/GoogleDriveService.java
@@ -96,7 +96,6 @@ public class GoogleDriveService {
                         .build();
 
         logger.info("구글 드라이브 인증 초기화 완료: {} - {}", APPLICATION_NAME, CONTEXT);
-
     }
 
     public String uploadFileBuffer(byte[] fileBuffer, String fileName) throws IOException {

--- a/techeerzip/src/main/java/backend/techeerzip/infra/s3/S3Service.java
+++ b/techeerzip/src/main/java/backend/techeerzip/infra/s3/S3Service.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import backend.techeerzip.global.logger.CustomLogger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.sync.RequestBody;


### PR DESCRIPTION
## 요약

사용자별 권한 설정

## 작업 내용

- Role 테이블에 company, bootcamp 데이터 추가 (4 -> company, 5 -> bootcamp)
- 외부인 회원가입 기능 추가
- 각 권한마다 허용되는 엔드포인트 설정

## 참고 사항

추가 기능 제외하고 엔드포인트 설정 완료
외부인 회원가입 때는 안 받는 데이터가 좀 있어서 몇몇 필수 필드 nullable 제거했습니다

## 관련 이슈

BACKEND-81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 외부 사용자 회원가입을 위한 신규 API 엔드포인트(/signup/external) 추가 및 관련 요청 DTO, Swagger 문서화 지원.
    - 사용자 가입 시 가입 사유(BOOTCAMP, COMPANY) 선택 가능.
- **개선 사항**
    - 역할(Role) 기반 인증 및 권한 부여 체계 강화: 각 API 엔드포인트별로 ADMIN, MENTOR, USER, COMPANY, BOOTCAMP 등 역할별 접근 권한 세분화.
    - 사용자 엔터티 일부 필드(year, isLft, githubUrl 등)에서 필수값(nullable = false) 제한 해제.
    - 사용자 역할 정보 처리 및 인증 로직 개선.
    - 사용자 가입 시 이메일 도메인 체크 강화 및 역할에 따른 권한 설정 추가.
    - 프로필 조회 시 역할에 따른 필터링 및 페이징 로직 개선.
- **버그 수정**
    - 이메일 인증 및 회원가입 시 도메인 체크 로직 개선 및 예외 처리 강화.
- **기타**
    - 불필요한 UserDto 클래스 삭제.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->