### PR TITLE
refactor: 권한별 접근 허용 엔드 포인트 수정

### DIFF
--- a/techeerzip/src/main/java/backend/techeerzip/domain/studyTeam/entity/StudyTeam.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/studyTeam/entity/StudyTeam.java
@@ -195,4 +195,8 @@ public class StudyTeam extends BaseEntity {
     public void remove(StudyMember sm) {
         this.studyMembers.remove(sm);
     }
+
+    public boolean isDeleted() {
+        return Boolean.TRUE.equals(this.isDeleted);
+    }
 }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/controller/UserController.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/controller/UserController.java
@@ -84,7 +84,7 @@ public class UserController implements UserSwagger {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/findPwd")
+    @PatchMapping("/password/reset")
     @Override
     public ResponseEntity<Void> resetPassword(
             @Valid @RequestBody ResetUserPasswordRequest userResetPasswordRequest) {

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/response/GetUserResponse.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/response/GetUserResponse.java
@@ -1,9 +1,7 @@
 package backend.techeerzip.domain.user.dto.response;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,7 +35,7 @@ public class GetUserResponse {
     private final Long id;
     private final String profileImage;
     private final String name;
-    private final Number roleId;
+    private final Integer roleId;
     private final String nickname;
     private final String email;
     private final String school;

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/response/GetUserResponse.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/response/GetUserResponse.java
@@ -1,7 +1,9 @@
 package backend.techeerzip.domain.user.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,7 +37,7 @@ public class GetUserResponse {
     private final Long id;
     private final String profileImage;
     private final String name;
-    private final Integer roleId;
+    private final Long roleId;
     private final String nickname;
     private final String email;
     private final String school;

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/response/GetUserResponse.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/dto/response/GetUserResponse.java
@@ -12,6 +12,7 @@ import lombok.Getter;
     "id",
     "profileImage",
     "name",
+    "roleId",
     "nickname",
     "email",
     "school",
@@ -36,6 +37,7 @@ public class GetUserResponse {
     private final Long id;
     private final String profileImage;
     private final String name;
+    private final Number roleId;
     private final String nickname;
     private final String email;
     private final String school;

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/entity/User.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/entity/User.java
@@ -1,17 +1,8 @@
 package backend.techeerzip.domain.user.entity;
 
-import backend.techeerzip.domain.blog.entity.Blog;
-import backend.techeerzip.domain.bookmark.entity.Bookmark;
-import backend.techeerzip.domain.event.entity.Event;
-import backend.techeerzip.domain.like.entity.Like;
-import backend.techeerzip.domain.projectMember.entity.ProjectMember;
-import backend.techeerzip.domain.resume.entity.Resume;
-import backend.techeerzip.domain.role.entity.Role;
-import backend.techeerzip.domain.session.entity.Session;
-import backend.techeerzip.domain.studyMember.entity.StudyMember;
-import backend.techeerzip.domain.techBloggingChallenge.entity.TechBloggingAttendance;
-import backend.techeerzip.domain.userExperience.entity.UserExperience;
-import backend.techeerzip.global.entity.BaseEntity;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,15 +16,27 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.util.ArrayList;
-import java.util.List;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import backend.techeerzip.domain.blog.entity.Blog;
+import backend.techeerzip.domain.bookmark.entity.Bookmark;
+import backend.techeerzip.domain.event.entity.Event;
+import backend.techeerzip.domain.like.entity.Like;
+import backend.techeerzip.domain.projectMember.entity.ProjectMember;
+import backend.techeerzip.domain.resume.entity.Resume;
+import backend.techeerzip.domain.role.entity.Role;
+import backend.techeerzip.domain.session.entity.Session;
+import backend.techeerzip.domain.studyMember.entity.StudyMember;
+import backend.techeerzip.domain.techBloggingChallenge.entity.TechBloggingAttendance;
+import backend.techeerzip.domain.userExperience.entity.UserExperience;
+import backend.techeerzip.global.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Entity
 @Getter

--- a/techeerzip/src/main/java/backend/techeerzip/domain/user/mapper/UserMapper.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/user/mapper/UserMapper.java
@@ -13,6 +13,7 @@ public class UserMapper {
                 .id(user.getId())
                 .profileImage(user.getProfileImage())
                 .name(user.getName())
+                .roleId(user.getRole().getId())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .school(user.getSchool())
@@ -29,6 +30,7 @@ public class UserMapper {
                 .projectTeams(
                         user.getProjectMembers().stream()
                                 .filter(pm -> pm.getProjectTeam() != null)
+                                .filter(pm -> !pm.getProjectTeam().isDeleted())
                                 .map(
                                         pm ->
                                                 GetUserResponse.ProjectTeamDTO.builder()
@@ -58,6 +60,7 @@ public class UserMapper {
                 .studyTeams(
                         user.getStudyMembers().stream()
                                 .filter(sm -> sm.getStudyTeam() != null)
+                                .filter(sm -> !sm.getStudyTeam().isDeleted())
                                 .map(
                                         sm ->
                                                 GetUserResponse.StudyTeamDTO.builder()
@@ -86,6 +89,7 @@ public class UserMapper {
                                 .toList())
                 .experiences(
                         user.getExperiences().stream()
+                                .filter(exp -> !exp.isDeleted())
                                 .map(
                                         exp ->
                                                 GetUserResponse.ExperienceDTO.builder()

--- a/techeerzip/src/main/java/backend/techeerzip/global/config/SecurityConfig.java
+++ b/techeerzip/src/main/java/backend/techeerzip/global/config/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
                                                 "/api/v3/bookmarks",
                                                 "/api/v3/likes",
                                                 "/api/v3/users",
-                                                "/api/v3/users/findPwd")
+                                                "/api/v3/users/password/reset")
                                         .hasAnyRole(
                                                 "ADMIN", "MENTOR", "TECHEER", "COMPANY", "BOOTCAMP")
 

--- a/techeerzip/src/main/java/backend/techeerzip/global/config/SecurityConfig.java
+++ b/techeerzip/src/main/java/backend/techeerzip/global/config/SecurityConfig.java
@@ -55,8 +55,6 @@ public class SecurityConfig {
                                         .hasRole("ADMIN")
 
                                         // Admin, Mentor, Techeer
-                                        .requestMatchers(HttpMethod.GET, "/api/v3/users")
-                                        .hasAnyRole("ADMIN", "MENTOR", "TECHEER")
                                         .requestMatchers(
                                                 HttpMethod.POST, "/api/v3/blogs", "/api/v3/events")
                                         .hasAnyRole("ADMIN", "MENTOR", "TECHEER")
@@ -71,17 +69,19 @@ public class SecurityConfig {
                                         .requestMatchers(
                                                 HttpMethod.GET,
                                                 "/api/v3/studyTeams/*",
-                                                "/api/v3/projectTeams/*",
-                                                "/api/v3/users/*")
+                                                "/api/v3/projectTeams/*")
                                         .hasAnyRole("ADMIN", "MENTOR", "TECHEER", "COMPANY")
-                                        .requestMatchers("/api/v3/resumes/**")
+                                        .requestMatchers(
+                                                "/api/v3/resumes/**", "/api/v3/users/profiles")
                                         .hasAnyRole("ADMIN", "MENTOR", "TECHEER", "COMPANY")
 
                                         // Admin, Mentor, Techeer, Company, Bootcamp
                                         .requestMatchers(
                                                 "/api/v3/events/**",
                                                 "/api/v3/bookmarks",
-                                                "/api/v3/likes")
+                                                "/api/v3/likes",
+                                                "/api/v3/users",
+                                                "/api/v3/users/findPwd")
                                         .hasAnyRole(
                                                 "ADMIN", "MENTOR", "TECHEER", "COMPANY", "BOOTCAMP")
 
@@ -92,9 +92,9 @@ public class SecurityConfig {
                                                 "/api/v3/auth/email",
                                                 "/api/v3/auth/code",
                                                 "/api/v3/auth/login",
+                                                "/api/v3/auth/logout",
                                                 "/api/v3/users/signup",
-                                                "/api/v3/users/signup/external",
-                                                "/api/v3/users/findPwd")
+                                                "/api/v3/users/signup/external")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())


### PR DESCRIPTION
## 요약

권한별 접근 허용 엔드 포인트 수정
삭제된 데이터 조회 안되게 수정

## 작업 내용

권한별 접근 허용 엔드 포인트 수정
삭제된 데이터 조회 안되게 수정

## 관련 이슈

BACKEND-85



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 사용자 정보 응답에 역할 ID(roleId)가 추가되었습니다.

- **버그 수정**
	- 삭제된 프로젝트 팀, 스터디 팀, 경험 정보가 사용자 정보 응답에서 제외됩니다.

- **리팩터**
	- 내부 코드 정리가 일부 진행되었습니다.

- **기타**
	- 일부 API 엔드포인트의 접근 권한이 조정되었습니다.  
	- `/api/v3/users/findPwd` 엔드포인트의 공개 접근이 제한되고, `/api/v3/auth/logout`이 공개 엔드포인트에 추가되었습니다.
	- 비밀번호 재설정 API 경로가 `/findPwd`에서 `/password/reset`으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->