### PR TITLE
fix: 프로젝트 스터디 전체 정렬, 이미지 삭제 수정

### DIFF
--- a/techeerzip/src/main/java/backend/techeerzip/TecheerzipApplication.java
+++ b/techeerzip/src/main/java/backend/techeerzip/TecheerzipApplication.java
@@ -2,11 +2,12 @@ package backend.techeerzip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-//@PropertySource("classpath:env.properties")
+@PropertySource("classpath:env.properties")
 public class TecheerzipApplication {
 
     public static void main(String[] args) {

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/dto/request/GetTeamsQuery.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/dto/request/GetTeamsQuery.java
@@ -44,8 +44,6 @@ public class GetTeamsQuery {
     @Min(1)
     private final int limit;
 
-    private final LocalDateTime createAt;
-
     @NotNull private final List<TeamType> teamTypes;
     private final SortType sortType;
     private final Boolean isRecruited;

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/dto/response/SliceNextCursor.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/dto/response/SliceNextCursor.java
@@ -32,7 +32,7 @@ public class SliceNextCursor {
     @Schema(description = "마지막 요소의 ID", example = "101")
     private final Long id;
 
-    @Schema(description = "커서 기준 날짜 (updatedAt 등)", example = "2024-10-01T12:00:00")
+    @Schema(description = "커서 기준 날짜 (updatedAt)", example = "2024-10-01T12:00:00")
     private final LocalDateTime dateCursor;
 
     @Schema(description = "커서 기준 정수값 (조회수, 좋아요 수 등)", example = "150")

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/entity/ProjectTeam.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/entity/ProjectTeam.java
@@ -2,6 +2,7 @@ package backend.techeerzip.domain.projectTeam.entity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -19,6 +20,7 @@ import backend.techeerzip.domain.projectTeam.dto.request.TeamData;
 import backend.techeerzip.domain.projectTeam.dto.response.LeaderInfo;
 import backend.techeerzip.domain.projectTeam.type.TeamRole;
 import backend.techeerzip.global.entity.BaseEntity;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -166,7 +168,7 @@ public class ProjectTeam extends BaseEntity {
     }
 
     public boolean isMainImageId(Long deleteImageId) {
-        return!mainImages.isEmpty() && deleteImageId.equals(mainImages.getFirst().getId());
+        return !mainImages.isEmpty() && deleteImageId.equals(mainImages.getFirst().getId());
     }
 
     public void updateMainImage(ProjectMainImage updateImage) {
@@ -252,5 +254,12 @@ public class ProjectTeam extends BaseEntity {
 
     public void updateResultImage(List<ProjectResultImage> images) {
         resultImages.addAll(images);
+    }
+
+    public boolean checkResultImage(List<Long> deleteResultImageIds) {
+        List<Long> imageIds = this.resultImages.stream()
+                .map(ProjectResultImage::getId)
+                .toList();
+        return new HashSet<>(imageIds).containsAll(deleteResultImageIds);
     }
 }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/entity/ProjectTeam.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/entity/ProjectTeam.java
@@ -20,7 +20,6 @@ import backend.techeerzip.domain.projectTeam.dto.request.TeamData;
 import backend.techeerzip.domain.projectTeam.dto.response.LeaderInfo;
 import backend.techeerzip.domain.projectTeam.type.TeamRole;
 import backend.techeerzip.global.entity.BaseEntity;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -257,9 +256,7 @@ public class ProjectTeam extends BaseEntity {
     }
 
     public boolean checkResultImage(List<Long> deleteResultImageIds) {
-        List<Long> imageIds = this.resultImages.stream()
-                .map(ProjectResultImage::getId)
-                .toList();
+        List<Long> imageIds = this.resultImages.stream().map(ProjectResultImage::getId).toList();
         return new HashSet<>(imageIds).containsAll(deleteResultImageIds);
     }
 }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/entity/ProjectTeam.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/entity/ProjectTeam.java
@@ -2,9 +2,10 @@ package backend.techeerzip.domain.projectTeam.entity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -255,8 +256,11 @@ public class ProjectTeam extends BaseEntity {
         resultImages.addAll(images);
     }
 
-    public boolean checkResultImage(List<Long> deleteResultImageIds) {
-        List<Long> imageIds = this.resultImages.stream().map(ProjectResultImage::getId).toList();
-        return new HashSet<>(imageIds).containsAll(deleteResultImageIds);
+    public boolean hasAllResultImageIds(Collection<Long> targetIds) {
+        Set<Long> existingIds =
+                this.resultImages.stream()
+                        .map(ProjectResultImage::getId)
+                        .collect(Collectors.toSet());
+        return existingIds.containsAll(targetIds);
     }
 }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/service/ProjectTeamService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/service/ProjectTeamService.java
@@ -401,14 +401,17 @@ public class ProjectTeamService {
             log.info("ProjectTeam update: 메인 이미지 저장 완료, imageId={}", image.getId());
         }
 
-        if (!resultImages.isEmpty()) {
-            if (!team.getResultImages().stream()
-                    .allMatch(i -> deleteResultImageIds.contains(i.getId()))) {
+        if (!deleteResultImageIds.isEmpty()) {
+            if (!team.checkResultImage(deleteMainImageId)) {
                 throw new ProjectTeamResultImageException();
             }
+            team.deleteResultImages(deleteResultImageIds);
+            log.info("ProjectTeam update: 결과 이미지 삭제 완료, imageIds={}", deleteResultImageIds);
+        }
+
+        if (!resultImages.isEmpty()) {
             final List<ProjectResultImage> images =
                     ProjectImageMapper.toResultEntities(resultImages, team);
-            team.deleteResultImages(deleteResultImageIds);
             team.updateResultImage(images);
             log.info("ProjectTeam update: 결과 이미지 저장 완료, count={}", images.size());
         }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/service/ProjectTeamService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/service/ProjectTeamService.java
@@ -402,7 +402,7 @@ public class ProjectTeamService {
         }
 
         if (!deleteResultImageIds.isEmpty()) {
-            if (!team.checkResultImage(deleteMainImageId)) {
+            if (!team.hasAllResultImageIds(deleteMainImageId)) {
                 throw new ProjectTeamResultImageException();
             }
             team.deleteResultImages(deleteResultImageIds);


### PR DESCRIPTION
## 요약
1. 전체 정렬 좋아요, 조회순 커서 추가
2. 이미지 삭제 로직 수정
<br><br>

## 작업 내용

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

BACKEND-

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 팀 목록 조회 시 생성일(createAt) 필터링이 제거되고, 정렬 및 커서 기반 페이징에서 기준 날짜가 업데이트일(updatedAt)로 통일되었습니다.
  - 팀 결과 이미지 삭제 및 검증 로직이 개선되어, 삭제 시 올바른 이미지 ID만 처리되도록 변경되었습니다.

- **기능 개선**
  - 외부 설정 파일(env.properties)에서 추가 설정을 불러올 수 있도록 지원합니다.
  - 결과 이미지 검증 기능이 추가되어 여러 이미지 ID의 존재 여부를 한 번에 확인할 수 있습니다.

- **문서**
  - 커서 기준 날짜의 Swagger 설명이 명확하게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->