### PR TITLE
Revert "fix: 프로젝트 스터디 전체 정렬, 이미지 삭제 수정"

### DIFF
--- a/techeerzip/src/main/java/backend/techeerzip/TecheerzipApplication.java
+++ b/techeerzip/src/main/java/backend/techeerzip/TecheerzipApplication.java
@@ -2,12 +2,11 @@ package backend.techeerzip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-@PropertySource("classpath:env.properties")
+//@PropertySource("classpath:env.properties")
 public class TecheerzipApplication {
 
     public static void main(String[] args) {

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/dto/request/GetTeamsQuery.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/dto/request/GetTeamsQuery.java
@@ -44,6 +44,8 @@ public class GetTeamsQuery {
     @Min(1)
     private final int limit;
 
+    private final LocalDateTime createAt;
+
     @NotNull private final List<TeamType> teamTypes;
     private final SortType sortType;
     private final Boolean isRecruited;

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/dto/response/SliceNextCursor.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/dto/response/SliceNextCursor.java
@@ -32,7 +32,7 @@ public class SliceNextCursor {
     @Schema(description = "마지막 요소의 ID", example = "101")
     private final Long id;
 
-    @Schema(description = "커서 기준 날짜 (updatedAt)", example = "2024-10-01T12:00:00")
+    @Schema(description = "커서 기준 날짜 (updatedAt 등)", example = "2024-10-01T12:00:00")
     private final LocalDateTime dateCursor;
 
     @Schema(description = "커서 기준 정수값 (조회수, 좋아요 수 등)", example = "150")

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/entity/ProjectTeam.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/entity/ProjectTeam.java
@@ -2,10 +2,8 @@ package backend.techeerzip.domain.projectTeam.entity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -168,7 +166,7 @@ public class ProjectTeam extends BaseEntity {
     }
 
     public boolean isMainImageId(Long deleteImageId) {
-        return !mainImages.isEmpty() && deleteImageId.equals(mainImages.getFirst().getId());
+        return!mainImages.isEmpty() && deleteImageId.equals(mainImages.getFirst().getId());
     }
 
     public void updateMainImage(ProjectMainImage updateImage) {
@@ -254,13 +252,5 @@ public class ProjectTeam extends BaseEntity {
 
     public void updateResultImage(List<ProjectResultImage> images) {
         resultImages.addAll(images);
-    }
-
-    public boolean hasAllResultImageIds(Collection<Long> targetIds) {
-        Set<Long> existingIds =
-                this.resultImages.stream()
-                        .map(ProjectResultImage::getId)
-                        .collect(Collectors.toSet());
-        return existingIds.containsAll(targetIds);
     }
 }

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/repository/querydsl/TeamUnionViewDslRepositoryImpl.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/repository/querydsl/TeamUnionViewDslRepositoryImpl.java
@@ -124,9 +124,8 @@ public class TeamUnionViewDslRepositoryImpl extends AbstractQuerydslRepository
         final LocalDateTime date = request.getDateCursor();
         final Integer count = request.getCountCursor();
         final SortType sortType = request.getSortType();
-        final LocalDateTime updateAt =
-                Optional.ofNullable(request.getDateCursor())
-                        .orElse(LocalDateTime.of(9999, 12, 31, 23, 59));
+        final LocalDateTime createAt =
+                Optional.ofNullable(request.getCreateAt()).orElse(LocalDateTime.MAX);
         log.info(
                 "TeamUnionView buildCursorCondition: 커서 조건 생성 시작 - sortType={}, id={}, dateCursor={}, countCursor={}",
                 sortType,
@@ -136,8 +135,8 @@ public class TeamUnionViewDslRepositoryImpl extends AbstractQuerydslRepository
 
         return switch (sortType) {
             case UPDATE_AT_DESC -> buildCursorForDate(date, TU.updatedAt, id);
-            case VIEW_COUNT_DESC -> buildCursorForInt(count, TU.viewCount, updateAt, id);
-            case LIKE_COUNT_DESC -> buildCursorForInt(count, TU.likeCount, updateAt, id);
+            case VIEW_COUNT_DESC -> buildCursorForInt(count, TU.viewCount, createAt, id);
+            case LIKE_COUNT_DESC -> buildCursorForInt(count, TU.likeCount, createAt, id);
         };
     }
 
@@ -146,21 +145,21 @@ public class TeamUnionViewDslRepositoryImpl extends AbstractQuerydslRepository
      *
      * @param fieldValue 기준이 되는 count 값
      * @param expr 정렬에 사용할 필드
-     * @param updateAt 생성 시간 기준
+     * @param createdAt 생성 시간 기준
      * @param id 기준 ID
      * @return BooleanExpression 형태의 커서 조건
      */
     private BooleanExpression buildCursorForInt(
-            Integer fieldValue, NumberPath<Integer> expr, LocalDateTime updateAt, Long id) {
-        if (fieldValue == null || updateAt == null || id == null) return null;
+            Integer fieldValue, NumberPath<Integer> expr, LocalDateTime createdAt, Long id) {
+        if (fieldValue == null || createdAt == null || id == null) return null;
 
         return expr.lt(fieldValue)
                 .or(
                         expr.eq(fieldValue)
                                 .and(
-                                        TU.updatedAt
-                                                .lt(updateAt)
-                                                .or(TU.updatedAt.eq(updateAt).and(TU.id.lt(id)))));
+                                        TU.createdAt
+                                                .lt(createdAt)
+                                                .or(TU.createdAt.eq(createdAt).and(TU.id.lt(id)))));
     }
 
     /**
@@ -214,7 +213,6 @@ public class TeamUnionViewDslRepositoryImpl extends AbstractQuerydslRepository
                             .hasNext(true)
                             .id(last.getId())
                             .countCursor(last.getViewCount())
-                            .dateCursor(last.getUpdatedAt())
                             .sortType(sortType)
                             .build();
             case LIKE_COUNT_DESC ->
@@ -222,7 +220,6 @@ public class TeamUnionViewDslRepositoryImpl extends AbstractQuerydslRepository
                             .hasNext(true)
                             .id(last.getId())
                             .countCursor(last.getLikeCount())
-                            .dateCursor(last.getUpdatedAt())
                             .sortType(sortType)
                             .build();
         };

--- a/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/service/ProjectTeamService.java
+++ b/techeerzip/src/main/java/backend/techeerzip/domain/projectTeam/service/ProjectTeamService.java
@@ -401,17 +401,14 @@ public class ProjectTeamService {
             log.info("ProjectTeam update: 메인 이미지 저장 완료, imageId={}", image.getId());
         }
 
-        if (!deleteResultImageIds.isEmpty()) {
-            if (!team.hasAllResultImageIds(deleteMainImageId)) {
+        if (!resultImages.isEmpty()) {
+            if (!team.getResultImages().stream()
+                    .allMatch(i -> deleteResultImageIds.contains(i.getId()))) {
                 throw new ProjectTeamResultImageException();
             }
-            team.deleteResultImages(deleteResultImageIds);
-            log.info("ProjectTeam update: 결과 이미지 삭제 완료, imageIds={}", deleteResultImageIds);
-        }
-
-        if (!resultImages.isEmpty()) {
             final List<ProjectResultImage> images =
                     ProjectImageMapper.toResultEntities(resultImages, team);
+            team.deleteResultImages(deleteResultImageIds);
             team.updateResultImage(images);
             log.info("ProjectTeam update: 결과 이미지 저장 완료, count={}", images.size());
         }


### PR DESCRIPTION
Reverts Techeer-Hogwarts/backend#33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 팀 조회 시 생성일(createAt) 필터 기능이 추가되었습니다.

- **버그 수정**
    - 팀 결과 이미지 업데이트 시, 새 이미지가 제공될 경우 기존 모든 결과 이미지가 삭제 대상에 포함되어야만 업데이트가 진행되도록 검증 로직이 개선되었습니다.

- **문서**
    - 일부 필드 설명이 더 명확하게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->